### PR TITLE
feat: return group elements, and return extension properties with documentation for elements

### DIFF
--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/BpmnElementType.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/BpmnElementType.kt
@@ -25,5 +25,6 @@ enum class BpmnElementType {
     BUSINESS_RULE_TASK,
     SCRIPT_TASK,
     SEND_TASK,
-    INCLUSIVE_GATEWAY
+    INCLUSIVE_GATEWAY,
+    GROUP
 }

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/service/BpmnElementExtensionProperties.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/service/BpmnElementExtensionProperties.kt
@@ -1,0 +1,6 @@
+package io.zeebe.zeeqs.data.service
+
+data class BpmnElementExtensionProperties (
+    val name: String? = null,
+    val value: String? = null,
+)

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/service/BpmnElementInfo.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/service/BpmnElementInfo.kt
@@ -1,10 +1,14 @@
 package io.zeebe.zeeqs.data.service
 
+import io.camunda.zeebe.model.bpmn.instance.Documentation
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeProperty
 import io.zeebe.zeeqs.data.entity.BpmnElementType
 
 data class BpmnElementInfo(
         val elementId: String,
         val elementName: String?,
         val elementType: BpmnElementType,
-        val metadata: BpmnElementMetadata
+        val metadata: BpmnElementMetadata,
+        val extensionProperties: Collection<BpmnElementExtensionProperties>?,
+        val documentation: String?
 )

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/service/ProcessInstanceService.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/service/ProcessInstanceService.kt
@@ -61,7 +61,7 @@ class ProcessInstanceService(
             return filteredProcessInstances;
         }
         else {
-            return processInstancesRepository.findByStateIn(stateIn, PageRequest.of(page, perPage)).toList();
+            return processInstancesRepository.findByProcessDefinitionKeyAndStateIn(processDefinitionKey, stateIn, PageRequest.of(page, perPage)).toList();
         }
     }
 
@@ -72,7 +72,7 @@ class ProcessInstanceService(
         }
 
         else {
-            return processInstancesRepository.countByStateIn(stateIn);
+            return processInstancesRepository.countByProcessDefinitionKeyAndStateIn(processDefinitionKey, stateIn);
         }
     }
 

--- a/data/src/test/kotlin/io/zeebe/zeeqs/ProcessServiceTest.kt
+++ b/data/src/test/kotlin/io/zeebe/zeeqs/ProcessServiceTest.kt
@@ -52,12 +52,12 @@ class ProcessServiceTest(
             // then
             assertThat(info)
                     .isNotNull()
-                    .contains(entry("s", BpmnElementInfo("s", "start", BpmnElementType.START_EVENT, BpmnElementMetadata())))
-                    .contains(entry("t", BpmnElementInfo("t", "task", BpmnElementType.SERVICE_TASK, BpmnElementMetadata(jobType = "test"))))
+                    .contains(entry("s", BpmnElementInfo("s", "start", BpmnElementType.START_EVENT, BpmnElementMetadata(), listOf(BpmnElementExtensionProperties()), "")))
+                    .contains(entry("t", BpmnElementInfo("t", "task", BpmnElementType.SERVICE_TASK, BpmnElementMetadata(jobType = "test"), listOf(BpmnElementExtensionProperties()), "")))
                     .contains(entry("u", BpmnElementInfo("u", "userTask", BpmnElementType.USER_TASK, BpmnElementMetadata(
-                            userTaskAssignmentDefinition = UserTaskAssignmentDefinition(assignee = "user1", candidateGroups = "group1"))))
+                            userTaskAssignmentDefinition = UserTaskAssignmentDefinition(assignee = "user1", candidateGroups = "group1")), listOf(BpmnElementExtensionProperties()), ""))
                     )
-                    .contains(entry("e", BpmnElementInfo("e", null, BpmnElementType.END_EVENT, BpmnElementMetadata())))
+                    .contains(entry("e", BpmnElementInfo("e", null, BpmnElementType.END_EVENT, BpmnElementMetadata(), listOf(BpmnElementExtensionProperties()), "")))
         }
 
         @Test
@@ -90,7 +90,8 @@ class ProcessServiceTest(
                                                     key = "camunda-forms:bpmn:form_A",
                                                     resource = """{"x":1}"""
                                             )
-                                    )
+                                    ),
+                                    listOf(BpmnElementExtensionProperties()), ""
                             )
                     )
         }

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/BpmnElementResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/BpmnElementResolver.kt
@@ -5,6 +5,7 @@ import io.zeebe.zeeqs.data.entity.ElementInstanceState
 import io.zeebe.zeeqs.data.entity.Process
 import io.zeebe.zeeqs.data.repository.ElementInstanceRepository
 import io.zeebe.zeeqs.data.repository.ProcessRepository
+import io.zeebe.zeeqs.data.service.BpmnElementExtensionProperties
 import io.zeebe.zeeqs.data.service.BpmnElementInfo
 import io.zeebe.zeeqs.data.service.BpmnElementMetadata
 import io.zeebe.zeeqs.data.service.ProcessService
@@ -39,6 +40,21 @@ class BpmnElementResolver(
         return findElementInfo(element)
                 ?.metadata
                 ?: BpmnElementMetadata()
+    }
+
+
+    @SchemaMapping(typeName = "BpmnElement", field = "extensionProperties")
+    fun extensionProperties(element: BpmnElement): Collection<BpmnElementExtensionProperties>? {
+        return findElementInfo(element)
+                ?.extensionProperties
+    }
+
+
+    @SchemaMapping(typeName = "BpmnElement", field = "documentation")
+    fun documentation(element: BpmnElement): String? {
+        return findElementInfo(element)
+                ?.documentation
+
     }
 
     @SchemaMapping(typeName = "BpmnElement", field = "process")

--- a/graphql-api/src/main/resources/graphql/Element.graphqls
+++ b/graphql-api/src/main/resources/graphql/Element.graphqls
@@ -10,6 +10,12 @@ type BpmnElement {
     # the metadata of the BPMN element
     metadata: BpmnElementMetadata!
 
+    # extension properties of the BPMN element
+    extensionProperties:  [BpmnElementExtensionProperties]
+
+    # documentation of the BPMN element
+    documentation: String
+
     # the process that contains the BPMN element
     process: Process
     # the instances of the BPMN element
@@ -46,6 +52,7 @@ enum BpmnElementType {
     SCRIPT_TASK
     SEND_TASK
     INCLUSIVE_GATEWAY
+    GROUP
 }
 
 # Additional metadata that are defined statically on the BPMN element.
@@ -84,4 +91,11 @@ type UserTaskAssignmentDefinition {
     assignee: String
     # the candidate groups
     candidateGroups: String
+}
+
+type BpmnElementExtensionProperties {
+    # the name of property
+    name: String
+    # the value of property
+    value: String
 }


### PR DESCRIPTION
## Description

* Return bpmn:group elements when retrieving elements of a process

* Return extensionProperties of element

* Return documentation of element

## Related issues

https://github.com/camunda-community-hub/zeeqs/issues/356

closes #
