### PR TITLE
feat: filter process instances by multiple variables

### DIFF
--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/BpmnElementType.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/BpmnElementType.kt
@@ -25,5 +25,6 @@ enum class BpmnElementType {
     BUSINESS_RULE_TASK,
     SCRIPT_TASK,
     SEND_TASK,
-    INCLUSIVE_GATEWAY
+    INCLUSIVE_GATEWAY,
+    GROUP
 }

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/VariableFilter.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/VariableFilter.kt
@@ -1,0 +1,12 @@
+package io.zeebe.zeeqs.data.entity
+
+enum class EqualityOperation {
+    EQUALS,
+    CONTAINS
+}
+
+class VariableFilter (
+        val name: String,
+        val value: String,
+        val equalityOperation: EqualityOperation = EqualityOperation.EQUALS
+)

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/repository/VariableRepository.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/repository/VariableRepository.kt
@@ -17,4 +17,8 @@ interface VariableRepository : PagingAndSortingRepository<Variable, Long> {
     @Transactional(readOnly = true)
     fun findByProcessInstanceKeyInAndName(processInstanceKey: List<Long>, name: String): List<Variable>
 
+
+    @Transactional(readOnly = true)
+    fun findByProcessInstanceKeyInAndNameIn(processInstanceKey: List<Long>, name: List<String>): List<Variable>
+
 }

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/service/BpmnElementExtensionProperties.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/service/BpmnElementExtensionProperties.kt
@@ -1,0 +1,6 @@
+package io.zeebe.zeeqs.data.service
+
+data class BpmnElementExtensionProperties (
+    val name: String? = null,
+    val value: String? = null,
+)

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/service/BpmnElementInfo.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/service/BpmnElementInfo.kt
@@ -1,10 +1,14 @@
 package io.zeebe.zeeqs.data.service
 
+import io.camunda.zeebe.model.bpmn.instance.Documentation
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeProperty
 import io.zeebe.zeeqs.data.entity.BpmnElementType
 
 data class BpmnElementInfo(
         val elementId: String,
         val elementName: String?,
         val elementType: BpmnElementType,
-        val metadata: BpmnElementMetadata
+        val metadata: BpmnElementMetadata,
+        val extensionProperties: Collection<BpmnElementExtensionProperties>?,
+        val documentation: String?
 )

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/service/ProcessInstanceService.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/service/ProcessInstanceService.kt
@@ -61,7 +61,7 @@ class ProcessInstanceService(
             return filteredProcessInstances;
         }
         else {
-            return processInstancesRepository.findByStateIn(stateIn, PageRequest.of(page, perPage)).toList();
+            return processInstancesRepository.findByProcessDefinitionKeyAndStateIn(processDefinitionKey, stateIn, PageRequest.of(page, perPage)).toList();
         }
     }
 
@@ -72,7 +72,7 @@ class ProcessInstanceService(
         }
 
         else {
-            return processInstancesRepository.countByStateIn(stateIn);
+            return processInstancesRepository.countByProcessDefinitionKeyAndStateIn(processDefinitionKey, stateIn);
         }
     }
 

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/service/ProcessService.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/service/ProcessService.kt
@@ -168,11 +168,15 @@ class ProcessService(val processRepository: ProcessRepository) {
     }
 
     private fun getExtensionProperties(element: BaseElement): Collection<BpmnElementExtensionProperties>? {
-       return element.extensionElements?.elementsQuery
+        return element.extensionElements?.elementsQuery
                 ?.filterByType(ZeebeProperties::class.java)
-                ?.singleResult()
-                ?.properties
-                ?.map { BpmnElementExtensionProperties(name = it.name, value = it.value) }
+                ?.findSingleResult()
+                ?.map { properties ->
+                    properties.properties?.map { property ->
+                        BpmnElementExtensionProperties(name = property.name, value = property.value)
+                    }
+                }
+                ?.orElse(null)
     }
 
 

--- a/data/src/test/kotlin/io/zeebe/zeeqs/ProcessServiceTest.kt
+++ b/data/src/test/kotlin/io/zeebe/zeeqs/ProcessServiceTest.kt
@@ -52,12 +52,12 @@ class ProcessServiceTest(
             // then
             assertThat(info)
                     .isNotNull()
-                    .contains(entry("s", BpmnElementInfo("s", "start", BpmnElementType.START_EVENT, BpmnElementMetadata(), listOf(BpmnElementExtensionProperties()), "")))
-                    .contains(entry("t", BpmnElementInfo("t", "task", BpmnElementType.SERVICE_TASK, BpmnElementMetadata(jobType = "test"), listOf(BpmnElementExtensionProperties()), "")))
+                    .contains(entry("s", BpmnElementInfo("s", "start", BpmnElementType.START_EVENT, BpmnElementMetadata(), null, "")))
+                    .contains(entry("t", BpmnElementInfo("t", "task", BpmnElementType.SERVICE_TASK, BpmnElementMetadata(jobType = "test"), null, "")))
                     .contains(entry("u", BpmnElementInfo("u", "userTask", BpmnElementType.USER_TASK, BpmnElementMetadata(
-                            userTaskAssignmentDefinition = UserTaskAssignmentDefinition(assignee = "user1", candidateGroups = "group1")), listOf(BpmnElementExtensionProperties()), ""))
+                            userTaskAssignmentDefinition = UserTaskAssignmentDefinition(assignee = "user1", candidateGroups = "group1")), null, ""))
                     )
-                    .contains(entry("e", BpmnElementInfo("e", null, BpmnElementType.END_EVENT, BpmnElementMetadata(), listOf(BpmnElementExtensionProperties()), "")))
+                    .contains(entry("e", BpmnElementInfo("e", null, BpmnElementType.END_EVENT, BpmnElementMetadata(), null, "")))
         }
 
         @Test
@@ -91,7 +91,7 @@ class ProcessServiceTest(
                                                     resource = """{"x":1}"""
                                             )
                                     ),
-                                    listOf(BpmnElementExtensionProperties()), ""
+                                    null, ""
                             )
                     )
         }

--- a/data/src/test/kotlin/io/zeebe/zeeqs/ProcessServiceTest.kt
+++ b/data/src/test/kotlin/io/zeebe/zeeqs/ProcessServiceTest.kt
@@ -52,12 +52,12 @@ class ProcessServiceTest(
             // then
             assertThat(info)
                     .isNotNull()
-                    .contains(entry("s", BpmnElementInfo("s", "start", BpmnElementType.START_EVENT, BpmnElementMetadata())))
-                    .contains(entry("t", BpmnElementInfo("t", "task", BpmnElementType.SERVICE_TASK, BpmnElementMetadata(jobType = "test"))))
+                    .contains(entry("s", BpmnElementInfo("s", "start", BpmnElementType.START_EVENT, BpmnElementMetadata(), listOf(BpmnElementExtensionProperties()), "")))
+                    .contains(entry("t", BpmnElementInfo("t", "task", BpmnElementType.SERVICE_TASK, BpmnElementMetadata(jobType = "test"), listOf(BpmnElementExtensionProperties()), "")))
                     .contains(entry("u", BpmnElementInfo("u", "userTask", BpmnElementType.USER_TASK, BpmnElementMetadata(
-                            userTaskAssignmentDefinition = UserTaskAssignmentDefinition(assignee = "user1", candidateGroups = "group1"))))
+                            userTaskAssignmentDefinition = UserTaskAssignmentDefinition(assignee = "user1", candidateGroups = "group1")), listOf(BpmnElementExtensionProperties()), ""))
                     )
-                    .contains(entry("e", BpmnElementInfo("e", null, BpmnElementType.END_EVENT, BpmnElementMetadata())))
+                    .contains(entry("e", BpmnElementInfo("e", null, BpmnElementType.END_EVENT, BpmnElementMetadata(), listOf(BpmnElementExtensionProperties()), "")))
         }
 
         @Test
@@ -90,7 +90,8 @@ class ProcessServiceTest(
                                                     key = "camunda-forms:bpmn:form_A",
                                                     resource = """{"x":1}"""
                                             )
-                                    )
+                                    ),
+                                    listOf(BpmnElementExtensionProperties()), ""
                             )
                     )
         }

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/query/ProcessInstanceQueryResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/query/ProcessInstanceQueryResolver.kt
@@ -2,6 +2,7 @@ package io.zeebe.zeeqs.graphql.resolvers.query
 
 import io.zeebe.zeeqs.data.entity.ProcessInstance
 import io.zeebe.zeeqs.data.entity.ProcessInstanceState
+import io.zeebe.zeeqs.data.entity.VariableFilter
 import io.zeebe.zeeqs.data.repository.ProcessInstanceRepository
 import io.zeebe.zeeqs.data.service.ProcessInstanceService
 import io.zeebe.zeeqs.graphql.resolvers.connection.ProcessInstanceConnection
@@ -22,12 +23,11 @@ class ProcessInstanceQueryResolver(
             @Argument perPage: Int,
             @Argument page: Int,
             @Argument stateIn: List<ProcessInstanceState>,
-            @Argument variableName: String?,
-            @Argument variableValue: String?
+            @Argument variables: List<VariableFilter>?
     ): ProcessInstanceConnection {
         return ProcessInstanceConnection(
-                getItems = { processInstanceService.getProcessInstances(perPage, page, stateIn, variableName, variableValue) },
-                getCount = { processInstanceService.countProcessInstances(stateIn, variableName, variableValue) }
+                getItems = { processInstanceService.getProcessInstances(perPage, page, stateIn, variables) },
+                getCount = { processInstanceService.countProcessInstances(stateIn, variables) }
         )
     }
 

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/BpmnElementResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/BpmnElementResolver.kt
@@ -5,6 +5,7 @@ import io.zeebe.zeeqs.data.entity.ElementInstanceState
 import io.zeebe.zeeqs.data.entity.Process
 import io.zeebe.zeeqs.data.repository.ElementInstanceRepository
 import io.zeebe.zeeqs.data.repository.ProcessRepository
+import io.zeebe.zeeqs.data.service.BpmnElementExtensionProperties
 import io.zeebe.zeeqs.data.service.BpmnElementInfo
 import io.zeebe.zeeqs.data.service.BpmnElementMetadata
 import io.zeebe.zeeqs.data.service.ProcessService
@@ -39,6 +40,21 @@ class BpmnElementResolver(
         return findElementInfo(element)
                 ?.metadata
                 ?: BpmnElementMetadata()
+    }
+
+
+    @SchemaMapping(typeName = "BpmnElement", field = "extensionProperties")
+    fun extensionProperties(element: BpmnElement): Collection<BpmnElementExtensionProperties>? {
+        return findElementInfo(element)
+                ?.extensionProperties
+    }
+
+
+    @SchemaMapping(typeName = "BpmnElement", field = "documentation")
+    fun documentation(element: BpmnElement): String? {
+        return findElementInfo(element)
+                ?.documentation
+
     }
 
     @SchemaMapping(typeName = "BpmnElement", field = "process")

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/ProcessResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/ProcessResolver.kt
@@ -30,8 +30,7 @@ class ProcessResolver(
         @Argument perPage: Int,
         @Argument page: Int,
         @Argument stateIn: List<ProcessInstanceState>,
-        @Argument variableName: String?,
-        @Argument variableValue: String?
+        @Argument variables: List<VariableFilter>?
     ): ProcessInstanceConnection {
         return ProcessInstanceConnection(
             getItems = {
@@ -40,16 +39,14 @@ class ProcessResolver(
                         page,
                         stateIn,
                         process.key,
-                        variableName,
-                        variableValue
+                        variables
                 ).toList()
             },
             getCount = {
                 processInstanceService.countProcessInstances(
                         stateIn,
                         process.key,
-                        variableName,
-                        variableValue
+                        variables
                 )
             }
         )

--- a/graphql-api/src/main/resources/graphql/Element.graphqls
+++ b/graphql-api/src/main/resources/graphql/Element.graphqls
@@ -10,6 +10,12 @@ type BpmnElement {
     # the metadata of the BPMN element
     metadata: BpmnElementMetadata!
 
+    # extension properties of the BPMN element
+    extensionProperties:  [BpmnElementExtensionProperties]
+
+    # documentation of the BPMN element
+    documentation: String
+
     # the process that contains the BPMN element
     process: Process
     # the instances of the BPMN element
@@ -46,6 +52,7 @@ enum BpmnElementType {
     SCRIPT_TASK
     SEND_TASK
     INCLUSIVE_GATEWAY
+    GROUP
 }
 
 # Additional metadata that are defined statically on the BPMN element.
@@ -84,4 +91,11 @@ type UserTaskAssignmentDefinition {
     assignee: String
     # the candidate groups
     candidateGroups: String
+}
+
+type BpmnElementExtensionProperties {
+    # the name of property
+    name: String
+    # the value of property
+    value: String
 }

--- a/graphql-api/src/main/resources/graphql/Process.graphqls
+++ b/graphql-api/src/main/resources/graphql/Process.graphqls
@@ -14,8 +14,7 @@ type Process {
         perPage: Int = 10,
         page: Int = 0,
         stateIn: [ProcessInstanceState!] = [ACTIVATED, COMPLETED, TERMINATED]
-        variableName: String = null,
-        variableValue: String = null): ProcessInstanceConnection!
+        variables: [VariableFilter] = null): ProcessInstanceConnection!
     # the scheduled timers of the timer start events of the process
     timers: [Timer!]
     # the opened message subscriptions of the message start events of the process

--- a/graphql-api/src/main/resources/graphql/ProcessInstance.graphqls
+++ b/graphql-api/src/main/resources/graphql/ProcessInstance.graphqls
@@ -74,8 +74,7 @@ type Query {
         perPage: Int = 10,
         page: Int = 0,
         stateIn: [ProcessInstanceState!] = [ACTIVATED, COMPLETED, TERMINATED],
-        variableName: String = null,
-        variableValue: String = null
+        variables: [VariableFilter] = null
     ): ProcessInstanceConnection!
 
 }

--- a/graphql-api/src/main/resources/graphql/Variable.graphqls
+++ b/graphql-api/src/main/resources/graphql/Variable.graphqls
@@ -14,3 +14,15 @@ type VariableUpdate {
     value: String!
     timestamp(zoneId: String = "Z"): String!
 }
+
+input VariableFilter {
+    name: String!,
+    value: String!,
+    equalityOperation: EqualityOperation = EQUALS
+}
+
+# The type of a variable value filter
+enum EqualityOperation {
+    EQUALS,
+    CONTAINS
+}


### PR DESCRIPTION
## Description

 filter process instances by multiple variables
 
*
`{
  process(key: 2251799813712348){
    key
    processInstances(variables: [

      {
        name: "receiver", 
        value:"cntxt.com",
        equalityOperation: CONTAINS
      }
    ]
    ) {
      totalCount
      nodes {
        key
        variables(globalOnly:true){
           name
        }
      }
    }
  }
}`
## Related issues

closes #
https://github.com/camunda-community-hub/zeeqs/issues/16