### PR TITLE
feat: add filter operation to variables filter

### DIFF
--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/VariableFilter.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/VariableFilter.kt
@@ -1,12 +1,22 @@
 package io.zeebe.zeeqs.data.entity
 
-enum class EqualityOperation {
+enum class ComparisonOperation {
     EQUALS,
     CONTAINS
+}
+
+enum class FilterOperation {
+    AND,
+    OR
 }
 
 class VariableFilter (
         val name: String,
         val value: String,
-        val equalityOperation: EqualityOperation = EqualityOperation.EQUALS
+        val comparisonOperation: ComparisonOperation = ComparisonOperation.EQUALS
+)
+
+class VariableFilterGroup (
+        val variables: List<VariableFilter>,
+        val filterOperation: FilterOperation = FilterOperation.OR
 )

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/query/ProcessInstanceQueryResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/query/ProcessInstanceQueryResolver.kt
@@ -2,7 +2,7 @@ package io.zeebe.zeeqs.graphql.resolvers.query
 
 import io.zeebe.zeeqs.data.entity.ProcessInstance
 import io.zeebe.zeeqs.data.entity.ProcessInstanceState
-import io.zeebe.zeeqs.data.entity.VariableFilter
+import io.zeebe.zeeqs.data.entity.VariableFilterGroup
 import io.zeebe.zeeqs.data.repository.ProcessInstanceRepository
 import io.zeebe.zeeqs.data.service.ProcessInstanceService
 import io.zeebe.zeeqs.graphql.resolvers.connection.ProcessInstanceConnection
@@ -23,11 +23,11 @@ class ProcessInstanceQueryResolver(
             @Argument perPage: Int,
             @Argument page: Int,
             @Argument stateIn: List<ProcessInstanceState>,
-            @Argument variables: List<VariableFilter>?
+            @Argument variablesFilter: VariableFilterGroup?
     ): ProcessInstanceConnection {
         return ProcessInstanceConnection(
-                getItems = { processInstanceService.getProcessInstances(perPage, page, stateIn, variables) },
-                getCount = { processInstanceService.countProcessInstances(stateIn, variables) }
+                getItems = { processInstanceService.getProcessInstances(perPage, page, stateIn, variablesFilter) },
+                getCount = { processInstanceService.countProcessInstances(stateIn, variablesFilter) }
         )
     }
 

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/ProcessResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/ProcessResolver.kt
@@ -30,7 +30,7 @@ class ProcessResolver(
         @Argument perPage: Int,
         @Argument page: Int,
         @Argument stateIn: List<ProcessInstanceState>,
-        @Argument variables: List<VariableFilter>?
+        @Argument variablesFilter: VariableFilterGroup?
     ): ProcessInstanceConnection {
         return ProcessInstanceConnection(
             getItems = {
@@ -39,14 +39,14 @@ class ProcessResolver(
                         page,
                         stateIn,
                         process.key,
-                        variables
+                        variablesFilter
                 ).toList()
             },
             getCount = {
                 processInstanceService.countProcessInstances(
                         stateIn,
                         process.key,
-                        variables
+                        variablesFilter
                 )
             }
         )

--- a/graphql-api/src/main/resources/graphql/Process.graphqls
+++ b/graphql-api/src/main/resources/graphql/Process.graphqls
@@ -14,7 +14,7 @@ type Process {
         perPage: Int = 10,
         page: Int = 0,
         stateIn: [ProcessInstanceState!] = [ACTIVATED, COMPLETED, TERMINATED]
-        variables: [VariableFilter] = null): ProcessInstanceConnection!
+        variablesFilter: VariableFilterGroup = null): ProcessInstanceConnection!
     # the scheduled timers of the timer start events of the process
     timers: [Timer!]
     # the opened message subscriptions of the message start events of the process

--- a/graphql-api/src/main/resources/graphql/ProcessInstance.graphqls
+++ b/graphql-api/src/main/resources/graphql/ProcessInstance.graphqls
@@ -74,7 +74,7 @@ type Query {
         perPage: Int = 10,
         page: Int = 0,
         stateIn: [ProcessInstanceState!] = [ACTIVATED, COMPLETED, TERMINATED],
-        variables: [VariableFilter] = null
+        variablesFilter: VariableFilterGroup = null
     ): ProcessInstanceConnection!
 
 }

--- a/graphql-api/src/main/resources/graphql/Variable.graphqls
+++ b/graphql-api/src/main/resources/graphql/Variable.graphqls
@@ -18,11 +18,20 @@ type VariableUpdate {
 input VariableFilter {
     name: String!,
     value: String!,
-    equalityOperation: EqualityOperation = EQUALS
+    comparisonOperation: ComparisonOperation!
 }
 
-# The type of a variable value filter
-enum EqualityOperation {
+input VariableFilterGroup {
+    variables: [VariableFilter!]
+    filterOperation: FilterOperation = OR
+}
+
+enum ComparisonOperation {
     EQUALS,
     CONTAINS
+}
+
+enum FilterOperation {
+    AND,
+    OR
 }


### PR DESCRIPTION
## Description

Allows filtering process instances by process variables:
```
{
  process(key: 2251799813712348){
    key
    processInstances(variablesFilter: {
      variables : [
      {
        name: "userEmail", 
        value:"myemail@gmail.com",
        comparisonOperation: EQUALS
      },
      {
        name: "processType", 
        value:"My Process Type",
        comparisonOperation: CONTAINS
      }          
      ],
      filterOperation: OR
    }
    ) {
      totalCount
      nodes {
        key
        variables(globalOnly: true){
           name
          value
        }
      }
    }
  }
}
```

## Related issues

https://github.com/camunda-community-hub/zeeqs/issues/16

closes #
