### PR TITLE
fix: concurrent modifications exception

### DIFF
--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/reactive/DataUpdatesPublisher.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/reactive/DataUpdatesPublisher.kt
@@ -2,19 +2,20 @@ package io.zeebe.zeeqs.data.reactive
 
 import io.zeebe.zeeqs.data.entity.*
 import org.springframework.stereotype.Component
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.function.Consumer
 
 @Component
 class DataUpdatesPublisher {
 
-    private val processListeners = mutableListOf<Consumer<Process>>()
-    private val decisionListeners = mutableListOf<Consumer<Decision>>()
-    private val processInstanceListeners = mutableListOf<Consumer<ProcessInstance>>()
-    private val elementInstanceListeners = mutableListOf<Consumer<ElementInstance>>()
-    private val variableListeners = mutableListOf<Consumer<Variable>>()
-    private val incidentListeners = mutableListOf<Consumer<Incident>>()
-    private val jobListeners = mutableListOf<Consumer<Job>>()
-    private val decisionEvaluationListeners = mutableListOf<Consumer<DecisionEvaluation>>()
+    private val processListeners = CopyOnWriteArrayList<Consumer<Process>>()
+    private val decisionListeners = CopyOnWriteArrayList<Consumer<Decision>>()
+    private val processInstanceListeners = CopyOnWriteArrayList<Consumer<ProcessInstance>>()
+    private val elementInstanceListeners = CopyOnWriteArrayList<Consumer<ElementInstance>>()
+    private val variableListeners = CopyOnWriteArrayList<Consumer<Variable>>()
+    private val incidentListeners = CopyOnWriteArrayList<Consumer<Incident>>()
+    private val jobListeners = CopyOnWriteArrayList<Consumer<Job>>()
+    private val decisionEvaluationListeners = CopyOnWriteArrayList<Consumer<DecisionEvaluation>>()
 
     fun onProcessUpdated(process: Process) {
         processListeners.forEach { it.accept(process) }


### PR DESCRIPTION
## Description

This fixes concurrent modifications exception:

```
ERROR 1 --- [pool-1-thread-1] i.z.h.connect.java.ZeebeHazelcast        : Fail to read from ring-buffer at sequence '11109979'. Will try again.

java.util.ConcurrentModificationException: null
	at java.base/java.util.ArrayList$Itr.checkForComodification(Unknown Source) ~[na:na]
	at java.base/java.util.ArrayList$Itr.next(Unknown Source) ~[na:na]
	at io.zeebe.zeeqs.data.reactive.DataUpdatesPublisher.onVariableUpdated(DataUpdatesPublisher.kt:91) ~[data-2.9.4.jar:2.9.4]
	at io.zeebe.zeeqs.importer.hazelcast.HazelcastImporter.importVariable(HazelcastImporter.kt:334) ~[hazelcast-importer-2.9.4.jar:2.9.4]
	at io.zeebe.zeeqs.importer.hazelcast.HazelcastImporter.importVariableRecord(HazelcastImporter.kt:320) ~[hazelcast-importer-2.9.4.jar:2.9.4]
	at io.zeebe.zeeqs.importer.hazelcast.HazelcastImporter.start$lambda$7(HazelcastImporter.kt:88) ~[hazelcast-importer-2.9.4.jar:2.9.4]
	at io.zeebe.hazelcast.connect.java.ZeebeHazelcast.lambda$handleRecord$0(ZeebeHazelcast.java:197) ~[zeebe-hazelcast-connector-1.4.0.jar:1.4.0]
	at java.base/java.util.ArrayList.forEach(Unknown Source) ~[na:na]
	at io.zeebe.hazelcast.connect.java.ZeebeHazelcast.handleRecord(ZeebeHazelcast.java:197) ~[zeebe-hazelcast-connector-1.4.0.jar:1.4.0]
	at io.zeebe.hazelcast.connect.java.ZeebeHazelcast.handleRecord(ZeebeHazelcast.java:182) ~[zeebe-hazelcast-connector-1.4.0.jar:1.4.0]
	at io.zeebe.hazelcast.connect.java.ZeebeHazelcast.readNext(ZeebeHazelcast.java:122) ~[zeebe-hazelcast-connector-1.4.0.jar:1.4.0]
	at io.zeebe.hazelcast.connect.java.ZeebeHazelcast.readFromBuffer(ZeebeHazelcast.java:111) ~[zeebe-hazelcast-connector-1.4.0.jar:1.4.0]
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source) ~[na:na]
	at java.base/java.util.concurrent.FutureTask.run(Unknown Source) ~[na:na]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source) ~[na:na]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source) ~[na:na]
	at java.base/java.lang.Thread.run(Unknown Source) ~[na:na]
```
*

## Related issues

N/A

closes #
